### PR TITLE
Corrected check for OrbText

### DIFF
--- a/src/System.Windows.Forms.Ribbon/Component Classes/Ribbon.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/Ribbon.cs
@@ -2346,7 +2346,7 @@ namespace System.Windows.Forms
 					}
 				}
 
-				if (OrbVisible && !_expanded && OrbText.Length > 0)
+				if (OrbVisible && !_expanded && !string.IsNullOrEmpty(OrbText))
 				{
 					if (OrbStyle == RibbonOrbStyle.Office_2010)
 					{


### PR DESCRIPTION
OrbText can be null so we have NullReferenceException.