### PR TITLE
Re-fix mouse events firing on Windows 10 April 2018 Update with high-dpi monitors

### DIFF
--- a/src/System.Windows.Forms.Ribbon/Classes/RibbonPopupManager.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/RibbonPopupManager.cs
@@ -131,18 +131,24 @@ namespace System.Windows.Forms
             //Al-74 fix (see GitHub issue #10):
             //Starting from Windows 10 April 2018 Update (version 1803) with display scaling above 100%, e.Location is the physical mouse location,
             //not scaled according to display scaling, so the Contains function fails check and no events fires when clicking RibbonButtons dropdown items.
-            //Returning always true should not generate any negative side effects.
-            return true;
-            //foreach (RibbonPopup p in pops)
-            //{
-            //    if (p.WrappedDropDown.Bounds.Contains(e.Location))
-            //    {
-            //        return true;
-            //    }
-            //}
-            ////If click was in no dropdown, let's go everyone
-            //Dismiss(DismissReason.AppClicked);
-            //	return false;
+            //Use GetCursorPos api instead of e.Location seems to solve the problem.
+
+            RibbonHelpers.WinApi.POINT pos;
+            if (RibbonHelpers.WinApi.GetCursorPos(out pos))
+            {
+                foreach (RibbonPopup p in pops)
+                {
+                    if (p.WrappedDropDown.Bounds.Contains(pos.x, pos.y))
+                    //if (p.WrappedDropDown.Bounds.Contains(e.Location))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            //If click was in no dropdown, let's go everyone
+            Dismiss(DismissReason.AppClicked);
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
see issue #10