### PR TITLE
Added VSLight and VSDark themes, CascadeEnabledFlag

### DIFF
--- a/src/System.Windows.Forms.Ribbon/Classes/Enums/Enums.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Enums/Enums.cs
@@ -15,7 +15,9 @@
         Green,
         Purple,
         JellyBelly,
-        Halloween
+        Halloween,
+        VSLight,
+        VSDark
     }
 
     public enum RibbonOrbStyle

--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/Color Tables/RibbonProfesionalRendererColorTable.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/Color Tables/RibbonProfesionalRendererColorTable.cs
@@ -222,6 +222,10 @@ namespace System.Windows.Forms
 
         public Color TextBoxUnselectedBg = FromHexStr("#EAF2FB");
         public Color TextBoxBorder = FromHexStr("#ABC1DE");
+        public Color TextBoxSelectedBg = SystemColors.Window;
+        public Color TextBoxSelectedBorder = FromHexStr("#ABC1DE");
+        public Color TextBoxDisabledBg = SystemColors.Control;
+        public Color TextBoxDisabledBorder = FromHexStr("#ABC1DE");
 
         public Color ToolTipContentNorth = Color.FromArgb(250, 252, 254);// SystemColors.MenuBar;// FromHex("#C8D9ED");
         public Color ToolTipContentSouth = Color.FromArgb(206, 220, 241);// SystemColors.MenuBar;// FromHex("#E7F2FF");
@@ -232,6 +236,7 @@ namespace System.Windows.Forms
         public Color ToolStripItemTextPressed = FromHexStr("#444444");
         public Color ToolStripItemTextSelected = FromHexStr("#444444");
         public Color ToolStripItemText = FromHexStr("#444444");
+        public Color ToolStripitemTextDisabled = Color.DarkGray;
 
         public Color clrVerBG_Shadow = Color.FromArgb(255, 181, 190, 206);
 

--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/Color Tables/RibbonProfesionalRendererColorTableVSDark.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/Color Tables/RibbonProfesionalRendererColorTableVSDark.cs
@@ -1,0 +1,189 @@
+// *********************************
+// Message from Original Author:
+//
+// 2008 Jose Menendez Poo
+// Please give me credit if you use this code. It's all I ask.
+// Contact me for more info: menendezpoo@gmail.com
+// *********************************
+//
+// Original project from http://ribbon.codeplex.com/
+// Continue to support and maintain by http://officeribbon.codeplex.com/
+
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    public class RibbonProfesionalRendererColorTableVSDark
+         : RibbonProfesionalRendererColorTable
+    {
+        public RibbonProfesionalRendererColorTableVSDark()
+        {
+            #region Fields
+
+            OrbDropDownDarkBorder = FromHex("#9BAFCA");
+            OrbDropDownLightBorder = FromHex("#FFFFFF");
+            OrbDropDownBack = FromHex("#BFD3EB");
+            OrbDropDownNorthA = FromHex("#D7E5F7");
+            OrbDropDownNorthB = FromHex("#D4E1F3");
+            OrbDropDownNorthC = FromHex("#C6D8EE");
+            OrbDropDownNorthD = FromHex("#B7CAE6");
+            OrbDropDownSouthC = FromHex("#B0C9EA");
+            OrbDropDownSouthD = FromHex("#CFE0F5");
+            OrbDropDownContentbg = FromHex("#E9EAEE");
+            OrbDropDownContentbglight = FromHex("#FAFAFA");
+            OrbDropDownSeparatorlight = FromHex("#F5F5F5");
+            OrbDropDownSeparatordark = FromHex("#C5C5C5");
+            Caption1 = FromHex("#E3EBF6");
+            Caption2 = FromHex("#DAE9FD");
+            Caption3 = FromHex("#D5E5FA");
+            Caption4 = FromHex("#D9E7F9");
+            Caption5 = FromHex("#CADEF7");
+            Caption6 = FromHex("#E4EFFD");
+            Caption7 = FromHex("#B0CFF7");
+            QuickAccessBorderDark = FromHex("#B6CAE2");
+            QuickAccessBorderLight = FromHex("#F2F6FB");
+            QuickAccessUpper = FromHex("#E0EBF9");
+            QuickAccessLower = FromHex("#C9D9EE");
+            OrbOptionBorder = FromHex("#7793B9");
+            OrbOptionBackground = FromHex("#E8F1FC");
+            OrbOptionShine = FromHex("#D2E1F4");
+
+            Arrow = FromHex("#999999");
+            ArrowLight = FromHex("#999999");
+            ArrowDisabled = FromHex("#B7B7B7");
+
+            Text = FromHex("#F1F1F1");
+            RibbonBackground = FromHex("#2D2D30");
+            TabBorder = FromHex("#252526");
+            TabSelectedBorder = FromHex("#B1B5BA");
+            TabNorth = FromHex("#2D2D30");
+            TabSouth = FromHex("#2D2D30");
+            TabGlow = FromHex("#2D2D30");
+            TabText = FromHex("#F1F1F1");
+            TabActiveText = FromHex("#F1F1F1");
+            TabContentNorth = FromHex("#2D2D30");
+            TabContentSouth = FromHex("#2D2D30");
+            TabSelectedGlow = FromHex("#2D2D30");
+            PanelDarkBorder = FromHex("#3E3E40");
+            PanelLightBorder = FromHex("#C0C0C0");
+            PanelTextBackground = FromHex("#333337");
+            PanelTextBackgroundSelected = FromHex("#333337");
+            PanelText = FromHex("#C0C0C0");
+            PanelBackgroundSelected = FromHex("#2D2D30");
+            PanelOverflowBackground = FromHex("#2D2D30");
+            PanelOverflowBackgroundPressed = FromHex("#2D2D30");
+            PanelOverflowBackgroundSelectedNorth = FromHex("#2D2D30");
+            PanelOverflowBackgroundSelectedSouth = FromHex("#2D2D30");
+            ButtonBgOut = FromHex("#3F3F46");
+            ButtonBgCenter = FromHex("#3F3F46");
+            ButtonBorderOut = FromHex("#555555");
+            ButtonBorderIn = FromHex("#555555");
+            ButtonGlossyNorth = FromHex("#3F3F46");
+            ButtonGlossySouth = FromHex("#3F3F46");
+            ButtonDisabledBgOut = FromHex("#2D2D30");
+            ButtonDisabledBgCenter = FromHex("#2D2D30");
+            ButtonDisabledBorderOut = FromHex("#3F3F46");
+            ButtonDisabledBorderIn = FromHex("#3F3F46");
+            ButtonDisabledGlossyNorth = FromHex("#2D2D30");
+            ButtonDisabledGlossySouth = FromHex("#2D2D30");
+            ButtonSelectedBgOut = FromHex("#3F3F46");
+            ButtonSelectedBgCenter = FromHex("#3F3F46");
+            ButtonSelectedBorderOut = FromHex("#007ACC");
+            ButtonSelectedBorderIn = FromHex("#007ACC");
+            ButtonSelectedGlossyNorth = FromHex("#3F3F46");
+            ButtonSelectedGlossySouth = FromHex("#3F3F46");
+            ButtonPressedBgOut = FromHex("#007ACC");
+            ButtonPressedBgCenter = FromHex("#007ACC");
+            ButtonPressedBorderOut = FromHex("#007ACC");
+            ButtonPressedBorderIn = FromHex("#007ACC");
+            ButtonPressedGlossyNorth = FromHex("#007ACC");
+            ButtonPressedGlossySouth = FromHex("#007ACC");
+            ButtonCheckedBgOut = FromHex("#3F3F46");
+            ButtonCheckedBgCenter = FromHex("#3F3F46");
+            ButtonCheckedBorderOut = FromHex("#007ACC");
+            ButtonCheckedBorderIn = FromHex("#007ACC");
+            ButtonCheckedGlossyNorth = FromHex("#3F3F46");
+            ButtonCheckedGlossySouth = FromHex("#3F3F46");
+            ButtonCheckedSelectedBgOut = FromHex("#3F3F46");
+            ButtonCheckedSelectedBgCenter = FromHex("#3F3F46");
+            ButtonCheckedSelectedBorderOut = FromHex("#007ACC");
+            ButtonCheckedSelectedBorderIn = FromHex("#007ACC");
+            ButtonCheckedSelectedGlossyNorth = FromHex("#3F3F46");
+            ButtonCheckedSelectedGlossySouth = FromHex("#3F3F46");
+            ItemGroupOuterBorder = FromHex("#555555");
+            ItemGroupInnerBorder = FromHex("#555555");
+            ItemGroupSeparatorLight = Color.FromArgb(64, FromHex("#FFFFFF"));
+            ItemGroupSeparatorDark = Color.FromArgb(38, FromHex("#9EBAE1"));
+            ItemGroupBgNorth = FromHex("#2D2D30");
+            ItemGroupBgSouth = FromHex("#2D2D30");
+            ItemGroupBgGlossy = FromHex("#2D2D30");
+            ButtonListBorder = FromHex("#434346");
+            ButtonListBg = FromHex("#2D2D30");
+            ButtonListBgSelected = FromHex("#3F3F46");
+            DropDownBg = FromHex("#1B1B1C");
+            DropDownImageBg = FromHex("#1B1B1C");
+            DropDownImageSeparator = FromHex("#434346");
+            DropDownBorder = FromHex("#3F3F46");
+            DropDownGripNorth = FromHex("#3F3F46");
+            DropDownGripSouth = FromHex("#3F3F46");
+            DropDownGripBorder = FromHex("#3F3F46");
+            DropDownGripDark = FromHex("#1B1B1C");
+            DropDownGripLight = FromHex("#FFFFFF");
+            DropDownCheckedButtonGlyphBg = FromHex("#FCF1C2");
+            DropDownCheckedButtonGlyphBorder = FromHex("#F29536");
+            SeparatorLight = Color.FromArgb(140, FromHex("#FFFFFF"));
+            SeparatorDark = FromHex("#434346");
+            QATSeparatorLight = Color.FromArgb(95, FromHex("#FFFFFF"));
+            QATSeparatorDark = FromHex("#999B9E");
+            SeparatorBg = FromHex("#DAE6EE");
+            SeparatorLine = FromHex("#434346");
+
+            TextBoxUnselectedBg = FromHex("#2D2D30");
+            TextBoxBorder = FromHex("#555555");
+            TextBoxSelectedBg = FromHex("#3F3F46");
+            TextBoxSelectedBorder = FromHex("#007ACC");
+            TextBoxDisabledBg = FromHex("#2D2D30");
+            TextBoxDisabledBorder = FromHex("#434346");
+
+            ToolTipContentNorth = FromHex("#F1F1F1");
+            ToolTipContentSouth = FromHex("#F1F1F1");
+            ToolTipDarkBorder = FromHex("#2D2D30");
+            ToolTipLightBorder = FromHex("#2D2D30");
+
+            ToolStripItemTextPressed = FromHex("#F1F1F1");
+            ToolStripItemTextSelected = FromHex("#F1F1F1");
+            ToolStripItemText = FromHex("#F1F1F1");
+            ToolStripitemTextDisabled = FromHex("#656565");
+
+            clrVerBG_Shadow = FromHex("#FFFFFF");
+
+            ButtonChecked_2013 = FromHex("#FFFFFF");
+            ButtonPressed_2013 = FromHex("#92C0E0");
+            ButtonSelected_2013 = FromHex("#CDE6F7");
+            OrbButton_2013 = FromHex("#0072C6");
+            OrbButtonSelected_2013 = FromHex("#2A8AD4");
+            OrbButtonPressed_2013 = FromHex("#2A8AD4");
+            TabText_2013 = FromHex("#0072C6");
+            TabTextSelected_2013 = FromHex("#444444");
+            PanelBorder_2013 = FromHex("#15428B");
+            RibbonBackground_2013 = FromHex("#FFFFFF");
+            TabCompleteBackground_2013 = FromHex("#FFFFFF");
+            TabNormalBackground_2013 = FromHex("#FFFFFF");
+            TabActiveBackbround_2013 = FromHex("#FFFFFF");
+            TabBorder_2013 = FromHex("#D4D4D4");
+            TabCompleteBorder_2013 = FromHex("#D4D4D4");
+            TabActiveBorder_2013 = FromHex("#D4D4D4");
+            OrbButtonText_2013 = FromHex("#FFFFFF");
+            PanelText_2013 = FromHex("#666666");
+            RibbonItemText_2013 = FromHex("#444444");
+            ToolTipText_2013 = FromHex("#262626");
+            ToolStripItemTextPressed_2013 = FromHex("#444444");
+            ToolStripItemTextSelected_2013 = FromHex("#444444");
+            ToolStripItemText_2013 = FromHex("#444444");
+
+            #endregion
+        }
+
+
+    }
+}

--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/Color Tables/RibbonProfesionalRendererColorTableVSLight.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/Color Tables/RibbonProfesionalRendererColorTableVSLight.cs
@@ -1,0 +1,189 @@
+// *********************************
+// Message from Original Author:
+//
+// 2008 Jose Menendez Poo
+// Please give me credit if you use this code. It's all I ask.
+// Contact me for more info: menendezpoo@gmail.com
+// *********************************
+//
+// Original project from http://ribbon.codeplex.com/
+// Continue to support and maintain by http://officeribbon.codeplex.com/
+
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    public class RibbonProfesionalRendererColorTableVSLight
+         : RibbonProfesionalRendererColorTable
+    {
+        public RibbonProfesionalRendererColorTableVSLight()
+        {
+            #region Fields
+
+            OrbDropDownDarkBorder = FromHex("#9BAFCA");
+            OrbDropDownLightBorder = FromHex("#FFFFFF");
+            OrbDropDownBack = FromHex("#BFD3EB");
+            OrbDropDownNorthA = FromHex("#D7E5F7");
+            OrbDropDownNorthB = FromHex("#D4E1F3");
+            OrbDropDownNorthC = FromHex("#C6D8EE");
+            OrbDropDownNorthD = FromHex("#B7CAE6");
+            OrbDropDownSouthC = FromHex("#B0C9EA");
+            OrbDropDownSouthD = FromHex("#CFE0F5");
+            OrbDropDownContentbg = FromHex("#E9EAEE");
+            OrbDropDownContentbglight = FromHex("#FAFAFA");
+            OrbDropDownSeparatorlight = FromHex("#F5F5F5");
+            OrbDropDownSeparatordark = FromHex("#C5C5C5");
+            Caption1 = FromHex("#E3EBF6");
+            Caption2 = FromHex("#DAE9FD");
+            Caption3 = FromHex("#D5E5FA");
+            Caption4 = FromHex("#D9E7F9");
+            Caption5 = FromHex("#CADEF7");
+            Caption6 = FromHex("#E4EFFD");
+            Caption7 = FromHex("#B0CFF7");
+            QuickAccessBorderDark = FromHex("#B6CAE2");
+            QuickAccessBorderLight = FromHex("#F2F6FB");
+            QuickAccessUpper = FromHex("#E0EBF9");
+            QuickAccessLower = FromHex("#C9D9EE");
+            OrbOptionBorder = FromHex("#7793B9");
+            OrbOptionBackground = FromHex("#E8F1FC");
+            OrbOptionShine = FromHex("#D2E1F4");
+
+            Arrow = FromHex("#717171");
+            ArrowLight = FromHex("#717171");
+            ArrowDisabled = FromHex("#B7B7B7");
+
+            Text = FromHex("#1E1E1E");
+            RibbonBackground = FromHex("#EEEEF2");
+            TabBorder = FromHex("#CCCEDB");
+            TabSelectedBorder = FromHex("#B1B5BA");
+            TabNorth = FromHex("#EEEEF2");
+            TabSouth = FromHex("#EEEEF2");
+            TabGlow = FromHex("#EEEEF2");
+            TabText = FromHex("#1E1E1E");
+            TabActiveText = FromHex("#1E1E1E");
+            TabContentNorth = FromHex("#EEEEF2");
+            TabContentSouth = FromHex("#EEEEF2");
+            TabSelectedGlow = FromHex("#EEEEF2");
+            PanelDarkBorder = FromHex("#3E3E40");
+            PanelLightBorder = FromHex("#C0C0C0");
+            PanelTextBackground = FromHex("#E1E6F1");
+            PanelTextBackgroundSelected = FromHex("#C9DEF5");
+            PanelText = FromHex("#1E1E1E");
+            PanelBackgroundSelected = FromHex("#EEEEF2");
+            PanelOverflowBackground = FromHex("#EEEEF2");
+            PanelOverflowBackgroundPressed = FromHex("#EEEEF2");
+            PanelOverflowBackgroundSelectedNorth = FromHex("#EEEEF2");
+            PanelOverflowBackgroundSelectedSouth = FromHex("#EEEEF2");
+            ButtonBgOut = FromHex("#ECECF0");
+            ButtonBgCenter = FromHex("#ECECF0");
+            ButtonBorderOut = FromHex("#CCCEDB");
+            ButtonBorderIn = FromHex("#CCCEDB");
+            ButtonGlossyNorth = FromHex("#ECECF0");
+            ButtonGlossySouth = FromHex("#ECECF0");
+            ButtonDisabledBgOut = FromHex("#F5F5F5");
+            ButtonDisabledBgCenter = FromHex("#F5F5F5");
+            ButtonDisabledBorderOut = FromHex("#CCCEDB");
+            ButtonDisabledBorderIn = FromHex("#CCCEDB");
+            ButtonDisabledGlossyNorth = FromHex("#F5F5F5");
+            ButtonDisabledGlossySouth = FromHex("#F5F5F5");
+            ButtonSelectedBgOut = FromHex("#C9DEF5");
+            ButtonSelectedBgCenter = FromHex("#C9DEF5");
+            ButtonSelectedBorderOut = FromHex("#CCCEDB");
+            ButtonSelectedBorderIn = FromHex("#CCCEDB");
+            ButtonSelectedGlossyNorth = FromHex("#C9DEF5");
+            ButtonSelectedGlossySouth = FromHex("#C9DEF5");
+            ButtonPressedBgOut = FromHex("#007ACC");
+            ButtonPressedBgCenter = FromHex("#007ACC");
+            ButtonPressedBorderOut = FromHex("#007ACC");
+            ButtonPressedBorderIn = FromHex("#007ACC");
+            ButtonPressedGlossyNorth = FromHex("#007ACC");
+            ButtonPressedGlossySouth = FromHex("#007ACC");
+            ButtonCheckedBgOut = FromHex("#F5F5F5");
+            ButtonCheckedBgCenter = FromHex("#F5F5F5");
+            ButtonCheckedBorderOut = FromHex("#CCCEDB");
+            ButtonCheckedBorderIn = FromHex("#CCCEDB");
+            ButtonCheckedGlossyNorth = FromHex("#F5F5F5");
+            ButtonCheckedGlossySouth = FromHex("#F5F5F5");
+            ButtonCheckedSelectedBgOut = FromHex("#F5F5F5");
+            ButtonCheckedSelectedBgCenter = FromHex("#F5F5F5");
+            ButtonCheckedSelectedBorderOut = FromHex("#007ACC");
+            ButtonCheckedSelectedBorderIn = FromHex("#007ACC");
+            ButtonCheckedSelectedGlossyNorth = FromHex("#F5F5F5");
+            ButtonCheckedSelectedGlossySouth = FromHex("#F5F5F5");
+            ItemGroupOuterBorder = FromHex("#CCCEDB");
+            ItemGroupInnerBorder = FromHex("#CCCEDB");
+            ItemGroupSeparatorLight = Color.FromArgb(64, FromHex("#FFFFFF"));
+            ItemGroupSeparatorDark = Color.FromArgb(38, FromHex("#9EBAE1"));
+            ItemGroupBgNorth = FromHex("#EEEEF2");
+            ItemGroupBgSouth = FromHex("#EEEEF2");
+            ItemGroupBgGlossy = FromHex("#EEEEF2");
+            ButtonListBorder = FromHex("#CCCEDB");
+            ButtonListBg = FromHex("#F6F6F6");
+            ButtonListBgSelected = FromHex("#F5F5F5");
+            DropDownBg = FromHex("#F6F6F6");
+            DropDownImageBg = FromHex("#F6F6F6");
+            DropDownImageSeparator = FromHex("#434346");
+            DropDownBorder = FromHex("#CCCEDB");
+            DropDownGripNorth = FromHex("#CCCEDB");
+            DropDownGripSouth = FromHex("#CCCEDB");
+            DropDownGripBorder = FromHex("#CCCEDB");
+            DropDownGripDark = FromHex("#1B1B1C");
+            DropDownGripLight = FromHex("#FFFFFF");
+            DropDownCheckedButtonGlyphBg = FromHex("#FCF1C2");
+            DropDownCheckedButtonGlyphBorder = FromHex("#F29536");
+            SeparatorLight = FromHex("#F5F5F5");
+            SeparatorDark = FromHex("#CCCEDB");
+            QATSeparatorLight = Color.FromArgb(95, FromHex("#FFFFFF"));
+            QATSeparatorDark = FromHex("#999B9E");
+            SeparatorBg = FromHex("#DAE6EE");
+            SeparatorLine = FromHex("#434346");
+
+            TextBoxUnselectedBg = FromHex("#FFFFFF");
+            TextBoxBorder = FromHex("#CCCEDB");
+            TextBoxSelectedBg = FromHex("#FFFFFF");
+            TextBoxSelectedBorder = FromHex("#007ACC");
+            TextBoxDisabledBg = FromHex("#EEEEF2");
+            TextBoxDisabledBorder = FromHex("#CCCEDB");
+
+            ToolTipContentNorth = FromHex("#ECECF0");
+            ToolTipContentSouth = FromHex("#ECECF0");
+            ToolTipDarkBorder = FromHex("#CCCEDB");
+            ToolTipLightBorder = FromHex("#CCCEDB");
+
+            ToolStripItemTextPressed = FromHex("#FFFFFF");
+            ToolStripItemTextSelected = FromHex("#1E1E1E");
+            ToolStripItemText = FromHex("#1E1E1E");
+            ToolStripitemTextDisabled = FromHex("#A2A4A5");
+
+            clrVerBG_Shadow = FromHex("#FFFFFF");
+
+            ButtonChecked_2013 = FromHex("#FFFFFF");
+            ButtonPressed_2013 = FromHex("#92C0E0");
+            ButtonSelected_2013 = FromHex("#CDE6F7");
+            OrbButton_2013 = FromHex("#0072C6");
+            OrbButtonSelected_2013 = FromHex("#2A8AD4");
+            OrbButtonPressed_2013 = FromHex("#2A8AD4");
+            TabText_2013 = FromHex("#0072C6");
+            TabTextSelected_2013 = FromHex("#444444");
+            PanelBorder_2013 = FromHex("#15428B");
+            RibbonBackground_2013 = FromHex("#FFFFFF");
+            TabCompleteBackground_2013 = FromHex("#FFFFFF");
+            TabNormalBackground_2013 = FromHex("#FFFFFF");
+            TabActiveBackbround_2013 = FromHex("#FFFFFF");
+            TabBorder_2013 = FromHex("#D4D4D4");
+            TabCompleteBorder_2013 = FromHex("#D4D4D4");
+            TabActiveBorder_2013 = FromHex("#D4D4D4");
+            OrbButtonText_2013 = FromHex("#FFFFFF");
+            PanelText_2013 = FromHex("#666666");
+            RibbonItemText_2013 = FromHex("#444444");
+            ToolTipText_2013 = FromHex("#1E1E1E");
+            ToolStripItemTextPressed_2013 = FromHex("#FFFFFF");
+            ToolStripItemTextSelected_2013 = FromHex("#1E1E1E");
+            ToolStripItemText_2013 = FromHex("#1E1E1E");
+
+            #endregion
+        }
+
+
+    }
+}

--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/RibbonProfessionalRenderer.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/RibbonProfessionalRenderer.cs
@@ -313,11 +313,13 @@ namespace System.Windows.Forms
         public void DrawArrowShaded(Graphics g, Rectangle b, RibbonArrowDirection d, bool enabled)
         {
             Size arrSize = arrowSize;
+            Point lightOffset = new Point(0, 1);
 
             if (d == RibbonArrowDirection.Left || d == RibbonArrowDirection.Right)
             {
                 //Invert size
-                arrSize = new Size(arrowSize.Height, arrowSize.Width);
+                arrSize = new Size(arrowSize.Height, arrowSize.Width + 1);
+                lightOffset = new Point(1, 0);
             }
 
             Point arrowP = new Point(
@@ -326,7 +328,8 @@ namespace System.Windows.Forms
                  );
 
             Rectangle bounds = new Rectangle(arrowP, arrSize);
-            Rectangle boundsLight = bounds; boundsLight.Offset(0, 1);
+            Rectangle boundsLight = bounds; 
+            boundsLight.Offset(lightOffset);
 
             Color lt = ColorTable.ArrowLight;
             Color dk = ColorTable.Arrow;
@@ -3614,13 +3617,13 @@ namespace System.Windows.Forms
         {
             using (GraphicsPath path = RoundRectangle(bounds, 3))
             {
-                using (SolidBrush b = new SolidBrush(SystemColors.Window))
+                using (SolidBrush b = new SolidBrush(ColorTable.TextBoxSelectedBg))
                 {
                     //g.FillPath(b, path);
                     g.FillRectangle(b, bounds);
                 }
 
-                using (Pen p = new Pen(ColorTable.TextBoxBorder))
+                using (Pen p = new Pen(ColorTable.TextBoxSelectedBorder))
                 {
                     //g.DrawPath(p, path);
                     g.DrawRectangle(p, bounds);

--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/ToolStripRenderer.cs
@@ -262,6 +262,12 @@ namespace System.Windows.Forms
             DrawText(e, e.Graphics);
         }
 
+        protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
+        {
+            e.ArrowColor = Theme.Standard.RendererColorTable.Arrow;
+            base.OnRenderArrow(e);
+        }
+
         protected override void OnRenderLabelBackground(ToolStripItemRenderEventArgs e)
         {
             base.OnRenderLabelBackground(e);
@@ -274,22 +280,22 @@ namespace System.Windows.Forms
         private void RenderBackground(ToolStripItemRenderEventArgs e)
         {
             //IF ITEM IS SELECTED OR CHECKED
-            if (e.Item.Selected | ((ToolStripButton)e.Item).Checked)
+            var button = e.Item as ToolStripButton;
+            if (e.Item.Selected || (button != null && button.Checked))
             {
                 RenderItemBackgroundSelected(e);
+                return;
             }
 
             //IF ITEM IS PRESSED
             if (e.Item.Pressed)
             {
                 RenderItemBackgroundPressed(e);
+                return;
             }
 
             //DEFAULT BACKGROUND
-            if (e.Item.Selected == false & e.Item.Pressed == false & ((ToolStripButton)e.Item).Checked == false)
-            {
-                RenderItemBackgroundDefault(e);
-            }
+            RenderItemBackgroundDefault(e);
         }
 
         private void RenderItemBackgroundSelected(ToolStripItemRenderEventArgs e)
@@ -499,19 +505,20 @@ namespace System.Windows.Forms
                     {
                         if (e.Item.Enabled)
                         {
-                            if (e.Item is ToolStripButton)
+                            var button = e.Item as ToolStripButton;
+                            if (button != null)
                             {
-                                if ((e.Item.Selected | e.Item.Pressed) & !((ToolStripButton)e.Item).Checked)
+                                if (button.Checked)
                                 {
-                                    e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextPressed_2013;
+                                    button.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextSelected_2013;
                                 }
-                                else if ((!e.Item.Selected & !e.Item.Pressed) & !((ToolStripButton)e.Item).Checked)
+                                else if (button.Selected || button.Pressed)
                                 {
-                                    e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemText_2013;
+                                    button.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextPressed_2013;
                                 }
-                                else if (((ToolStripButton)e.Item).Checked)
+                                else
                                 {
-                                    e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextSelected_2013;
+                                    button.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemText_2013;
                                 }
                             }
                             else if (e.Item is ToolStripLabel)
@@ -530,26 +537,27 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (e.Item.Text != string.Empty)
+                    if (!string.IsNullOrEmpty(e.Item.Text))
                     {
                         if (e.Item.Enabled)
                         {
-                            if (e.Item is ToolStripButton)
+                            var button = e.Item as ToolStripButton;
+                            if (button != null)
                             {
-                                if ((e.Item.Selected | e.Item.Pressed) & !((ToolStripButton)e.Item).Checked)
+                                if (button.Checked)
                                 {
-                                    e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextPressed;
+                                    button.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextSelected;
                                 }
-                                else if ((!e.Item.Selected & !e.Item.Pressed) & !((ToolStripButton)e.Item).Checked)
+                                else if (button.Selected || button.Pressed)
                                 {
-                                    e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemText;
+                                    button.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextPressed;
                                 }
-                                else if (((ToolStripButton)e.Item).Checked)
+                                else
                                 {
-                                    e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemTextSelected;
+                                    button.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemText;
                                 }
                             }
-                            else if (e.Item is ToolStripLabel)
+                            else
                             {
                                 e.Item.ForeColor = Theme.Standard.RendererColorTable.ToolStripItemText;
                             }

--- a/src/System.Windows.Forms.Ribbon/Classes/Theme.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Theme.cs
@@ -79,6 +79,10 @@
                     RendererColorTable = new RibbonProfesionalRendererColorTableJellyBelly();
                 else if (_Theme == RibbonTheme.Halloween)
                     RendererColorTable = new RibbonProfesionalRendererColorTableHalloween();
+                else if (_Theme == RibbonTheme.VSLight)
+                    RendererColorTable = new RibbonProfesionalRendererColorTableVSLight();
+                else if (_Theme == RibbonTheme.VSDark)
+                    RendererColorTable = new RibbonProfesionalRendererColorTableVSDark();
             }
         }
 

--- a/src/System.Windows.Forms.Ribbon/Component Classes/RibbonButton.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/RibbonButton.cs
@@ -641,9 +641,10 @@ namespace System.Windows.Forms
             {
                 if (Image != null)
                 {
+                    int marginTop = Owner == null ? 0 : Owner.ItemMargin.Top;
                     return new Rectangle(
                     Bounds.Left + ((Bounds.Width - Image.Width) / 2),
-                    Bounds.Top + Owner.ItemMargin.Top,
+                    Bounds.Top + marginTop,
                     Image.Width,
                     Image.Height);
                 }
@@ -687,11 +688,22 @@ namespace System.Windows.Forms
 
             if (sMode == RibbonElementSizeMode.Large)
             {
-                return Rectangle.FromLTRB(
-                    Bounds.Left + Owner.ItemMargin.Left,
-                    Bounds.Top + Owner.ItemMargin.Top + imgh,
-                    Bounds.Right - Owner.ItemMargin.Right,
-                    Bounds.Bottom - Owner.ItemMargin.Bottom);
+                if (Owner == null)
+                {
+                    return Rectangle.FromLTRB(
+                        Bounds.Left,
+                        Bounds.Top + imgh,
+                        Bounds.Right,
+                        Bounds.Bottom);
+                }
+                else
+                {
+                    return Rectangle.FromLTRB(
+                        Bounds.Left + Owner.ItemMargin.Left,
+                        Bounds.Top + Owner.ItemMargin.Top + imgh,
+                        Bounds.Right - Owner.ItemMargin.Right,
+                        Bounds.Bottom - Owner.ItemMargin.Bottom);
+                }
             }
 
             // ddw is the dropdown arrow width
@@ -834,7 +846,7 @@ namespace System.Windows.Forms
         /// <returns></returns>
         public override Size MeasureSize(object sender, RibbonElementMeasureSizeEventArgs e)
         {
-            if (!Visible && !Owner.IsDesignMode())
+            if (Owner == null || (!Visible && !Owner.IsDesignMode()))
             {
                 SetLastMeasuredSize(new Size(0, 0));
                 return LastMeasuredSize;

--- a/src/System.Windows.Forms.Ribbon/Component Classes/RibbonPanel.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/RibbonPanel.cs
@@ -194,6 +194,11 @@ namespace System.Windows.Forms
 
         [DefaultValue(true)]
         [Category("Behavior")]
+        [Description("Sets if changes to this panel's Enabled flag should be cascaded to its children")]
+        public bool CascadeEnabledFlag { get; set; } = true;
+
+		[DefaultValue(true)]
+		[Category("Behavior")]
         [Description("Sets if the panel should be enabled")]
         public bool Enabled
         {
@@ -210,13 +215,15 @@ namespace System.Windows.Forms
             {
                 _enabled = value;
                 Owner.Invalidate();
-
+                if (CascadeEnabledFlag)
+                {
                 foreach (RibbonItem item in Items)
                 {
                     item.Enabled = value;
                 }
             }
         }
+		}
 
         [DefaultValue(true)]
         [Category("Behavior")]

--- a/src/System.Windows.Forms.Ribbon/System.Windows.Forms.Ribbon.csproj
+++ b/src/System.Windows.Forms.Ribbon/System.Windows.Forms.Ribbon.csproj
@@ -56,6 +56,26 @@
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Release\System.Windows.Forms.Ribbon.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET2</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NET2</DefineConstants>
+    <DocumentationFile>bin\Release\System.Windows.Forms.Ribbon.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Design" />
@@ -80,6 +100,8 @@
     <Compile Include="Classes\Interfaces\IRibbonToolTip.cs" />
     <Compile Include="Classes\Interfaces\IScrollableRibbonItem.cs" />
     <Compile Include="Classes\LayoutHelper.cs" />
+    <Compile Include="Classes\Renderers\Color Tables\RibbonProfesionalRendererColorTableVSLight.cs" />
+    <Compile Include="Classes\Renderers\Color Tables\RibbonProfesionalRendererColorTableVSDark.cs" />
     <Compile Include="Classes\Renderers\Color Tables\RibbonProfesionalRendererColorTableBlue.cs" />
     <Compile Include="Classes\Renderers\Color Tables\RibbonProfesionalRendererColorTableBlue2010.cs" />
     <Compile Include="Classes\Renderers\Color Tables\RibbonProfesionalRendererColorTableGreen.cs" />


### PR DESCRIPTION
VSLight and VSDark themes are meant to mirror similar themes in the DockPanel Suite for WinForms (specifically the VS2015 themes). CascadeEnabledFlag defaults to true for backward compatibility, but when set to false makes the Panel's "Enabled" flag work like other WInForms controls.