### PR TITLE
Fix Issue #11, "OrbStyle":

### DIFF
--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/RibbonProfessionalRenderer.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/RibbonProfessionalRenderer.cs
@@ -216,6 +216,19 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        /// Creates a <see cref="RoundRectangle(Rectangle, int)"/> or a <see cref="FlatRectangle(Rectangle)"/>,
+        /// in dependence of <paramref name="bordersAreRounded"/>.
+        /// </summary>
+        /// <param name="r">The rectangle.</param>
+        /// <param name="bordersAreRounded">Triggers roundness at all.</param>
+        /// <param name="radius">Roundness of corners, if rounded.</param>
+        /// <returns>The requested <see cref="GraphicsPath"/></returns>
+        public static GraphicsPath PopupRectangle(Rectangle r, bool bordersAreRounded, int radius)
+        {
+            return bordersAreRounded ? RoundRectangle(r, radius) : FlatRectangle(r);
+        }
+
+        /// <summary>
         /// Draws a rectangle with a vertical gradient
         /// </summary>
         /// <param name="g"></param>
@@ -4252,8 +4265,9 @@ namespace System.Windows.Forms
             Color OrbDropDownSeparatorlight = ColorTable.OrbDropDownSeparatorlight;
             Color OrbDropDownSeparatordark = ColorTable.OrbDropDownSeparatordark;
 
-            GraphicsPath innerPath = RoundRectangle(InnerRect, 6);
-            GraphicsPath outerPath = RoundRectangle(OuterRect, 6);
+            // 17/09/19: tajbender: Why was an default value of 6 used, not BorderRoundness-Property?
+            GraphicsPath innerPath = PopupRectangle(InnerRect, e.RibbonOrbDropDown.BordersAreRounded, e.RibbonOrbDropDown.BorderRoundness);
+            GraphicsPath outerPath = PopupRectangle(OuterRect, e.RibbonOrbDropDown.BordersAreRounded, e.RibbonOrbDropDown.BorderRoundness);
 
             e.Graphics.SmoothingMode = SmoothingMode.None;
 
@@ -5417,7 +5431,7 @@ namespace System.Windows.Forms
             {
                 if (dd != null)
                 {
-                    using (GraphicsPath r = RoundRectangle(new Rectangle(Point.Empty, new Size(dd.Size.Width - 1, dd.Size.Height - 1)), dd.BorderRoundness))
+                    using (GraphicsPath r = PopupRectangle(new Rectangle(Point.Empty, new Size(dd.Size.Width - 1, dd.Size.Height - 1)), dd.BordersAreRounded, dd.BorderRoundness))
                     {
                         SmoothingMode smb = e.Graphics.SmoothingMode;
                         e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;

--- a/src/System.Windows.Forms.Ribbon/Component Classes/Ribbon.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/Ribbon.cs
@@ -764,6 +764,8 @@ namespace System.Windows.Forms
                     ItemMargin = new Padding(4, 2, 4, 2);
                     ItemPadding = new Padding(1, 0, 1, 0);
                     ItemImageToTextSpacing = 4;
+
+                    OrbDropDown.BordersAreRounded = true;
                 }
                 else if ((value == RibbonOrbStyle.Office_2010) ||
                          (value == RibbonOrbStyle.Office_2010_Extended))
@@ -789,6 +791,8 @@ namespace System.Windows.Forms
                     ItemMargin = new Padding(3, 2, 0, 2);
                     ItemPadding = new Padding(1, 0, 1, 0);
                     ItemImageToTextSpacing = 11;
+
+                    OrbDropDown.BordersAreRounded = false;
                 }
                 else if (value == RibbonOrbStyle.Office_2013)
                 {
@@ -813,6 +817,8 @@ namespace System.Windows.Forms
                     ItemMargin = new Padding(2, 2, 0, 2);
                     ItemPadding = new Padding(1, 0, 1, 0);
                     ItemImageToTextSpacing = 11;
+
+                    OrbDropDown.BordersAreRounded = false;
                 }
                 UpdateRegions();
                 Invalidate();

--- a/src/System.Windows.Forms.Ribbon/Component Classes/RibbonDropDown.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/RibbonDropDown.cs
@@ -118,6 +118,7 @@ namespace System.Windows.Forms
             Sensor = new RibbonMouseSensor(this, OwnerRibbon, items);
             MeasuringSize = measuringSize;
             ScrollBarSize = 16;
+            this.BordersAreRounded = ownerRibbon.OrbDropDown.BordersAreRounded;     // HACK: 18/09/19: tajbender: Issue #11, just use OrbDropDown's BordersAreRounded-Property
 
             if (Items != null)
                 foreach (RibbonItem item in Items)

--- a/src/System.Windows.Forms.Ribbon/Component Classes/RibbonOrbDropDown.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/RibbonOrbDropDown.cs
@@ -55,8 +55,8 @@ namespace System.Windows.Forms
             OptionItems.SetOwner(Ribbon);
 
             OptionItemsPadding = 6;
-            Size = new Size(527, 447);
-            BorderRoundness = 8;
+            Size = new Size(527, 447);                                                  // 04/09/19: tajbender: Why is an initial size set?!? That may be the cause for some flicker, I'm pretty sure
+            BorderRoundness = 8;                                                        // Setting default value for BorderRoundness
 
             //if (!(Site != null && Site.DesignMode))
             //{

--- a/src/System.Windows.Forms.Ribbon/Component Classes/RibbonPopup.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/RibbonPopup.cs
@@ -55,7 +55,6 @@ namespace System.Windows.Forms
             SetStyle(ControlStyles.AllPaintingInWmPaint, true);
             SetStyle(ControlStyles.UserPaint, true);
             SetStyle(ControlStyles.Selectable, false);
-            BorderRoundness = 3;
         }
 
         #endregion
@@ -63,11 +62,24 @@ namespace System.Windows.Forms
         #region Props
 
         /// <summary>
-        /// Gets or sets the roundness of the border
+        /// Gets or sets the roundness of the border.
+        /// 
+        /// This property is only valid when <see cref="BordersAreRounded"/> is true.
         /// </summary>
         [Browsable(false)]
-        public int BorderRoundness { get; set; }
+        [DefaultValue(3)]
+        public int BorderRoundness { get; set; } = 3;
 
+        /// <summary>
+        /// Enable or disable the roundness of the border.
+        /// 
+        /// For <seealso cref="RibbonOrbDropDown"/> this property is triggered when changing the <seealso cref="RibbonOrbStyle"/> using <seealso cref="Ribbon.OrbStyle"/>.
+        /// 
+        /// The radius is controlled by <see cref="BorderRoundness"/>.
+        /// </summary>
+        [Browsable(false)]
+        [DefaultValue(true)]
+        public bool BordersAreRounded { get; set; } = true;
 
         /// <summary>
         /// Gets the related ToolStripDropDown
@@ -220,7 +232,7 @@ namespace System.Windows.Forms
         {
             base.OnPaint(e);
 
-            using (GraphicsPath p = RibbonProfessionalRenderer.RoundRectangle(new Rectangle(Point.Empty, Size), BorderRoundness))
+            using (GraphicsPath p = RibbonProfessionalRenderer.PopupRectangle(new Rectangle(Point.Empty, this.Size), this.BordersAreRounded, this.BorderRoundness))
             {
                 using (Region r = new Region(p))
                 {


### PR DESCRIPTION
- Introduce RibbonPopup.BordersAreRounded-Property, which is set in dependence of RibbonOrbStyle of Ribbon

@adriancs2: Adrian, please have a look at these changes, which address Issue #11 , "OrbStyle". I've introduced a new (internal) property, `RibbonPopup`.`BordersAreRounded`.

It defaults to true, but is changed by setting `Ribbon`.`RibbonOrbStyle`. So finally, only Office 2007-Popups should have rounded edges, not those in Office 2010 or Office 2013-Style. This not only affects  `OrbDropDown`, but also `RibbonPopup` as used for ComboBoxes e.g.

I've tested this using Windows 10, but I'm sure it should work regardless of OS-version. I've used the way of introducing a new `boolean`-property to avoid any implications, but as always, four eyes see more then two :)

So please test this in any way you can imagine. If you have questions, thoughts, etc., just drop a line. Thanks in advance.