### PR TITLE
Fix Issue #11, "OrbStyle" - New and easy approach

### DIFF
--- a/src/System.Windows.Forms.Ribbon/Classes/Renderers/RibbonProfessionalRenderer.cs
+++ b/src/System.Windows.Forms.Ribbon/Classes/Renderers/RibbonProfessionalRenderer.cs
@@ -4252,8 +4252,13 @@ namespace System.Windows.Forms
             Color OrbDropDownSeparatorlight = ColorTable.OrbDropDownSeparatorlight;
             Color OrbDropDownSeparatordark = ColorTable.OrbDropDownSeparatordark;
 
-            GraphicsPath innerPath = RoundRectangle(InnerRect, 6);
-            GraphicsPath outerPath = RoundRectangle(OuterRect, 6);
+            // Issue #11: OrbStyle
+            int minorBorderRoundness = e.RibbonOrbDropDown.BorderRoundness - 2;
+            if (minorBorderRoundness < 0)
+                minorBorderRoundness = 0;
+
+            GraphicsPath innerPath = RoundRectangle(InnerRect, minorBorderRoundness);
+            GraphicsPath outerPath = RoundRectangle(OuterRect, minorBorderRoundness);
 
             e.Graphics.SmoothingMode = SmoothingMode.None;
 

--- a/src/System.Windows.Forms.Ribbon/Component Classes/Ribbon.cs
+++ b/src/System.Windows.Forms.Ribbon/Component Classes/Ribbon.cs
@@ -728,7 +728,9 @@ namespace System.Windows.Forms
         public Theme Theme => _theme == null ? Theme.Standard : _theme;
 
         /// <summary>
-        /// Gets or sets the Style of the orb
+        /// Gets or sets the Style of the orb.
+        /// 
+        /// This is where the default values are loaded when changing the OrbStyle.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         [Category("Orb")]
@@ -764,6 +766,7 @@ namespace System.Windows.Forms
                     ItemMargin = new Padding(4, 2, 4, 2);
                     ItemPadding = new Padding(1, 0, 1, 0);
                     ItemImageToTextSpacing = 4;
+                    this.OrbDropDown.BorderRoundness = 8;
                 }
                 else if ((value == RibbonOrbStyle.Office_2010) ||
                          (value == RibbonOrbStyle.Office_2010_Extended))
@@ -789,6 +792,7 @@ namespace System.Windows.Forms
                     ItemMargin = new Padding(3, 2, 0, 2);
                     ItemPadding = new Padding(1, 0, 1, 0);
                     ItemImageToTextSpacing = 11;
+                    this.OrbDropDown.BorderRoundness = 2;
                 }
                 else if (value == RibbonOrbStyle.Office_2013)
                 {
@@ -813,6 +817,7 @@ namespace System.Windows.Forms
                     ItemMargin = new Padding(2, 2, 0, 2);
                     ItemPadding = new Padding(1, 0, 1, 0);
                     ItemImageToTextSpacing = 11;
+                    this.OrbDropDown.BorderRoundness = 2;
                 }
                 UpdateRegions();
                 Invalidate();


### PR DESCRIPTION
- Set BorderRoundness = 2 for Office 2010/13 (instead of removing Roundness completely). This mimics the default Windows Ribbon, as @harborsiem pointed out.

Instead of my old pull request, https://github.com/RibbonWinForms/RibbonWinForms/pull/47, this one won't disable the roundness at all, but will just set a slightly, barely visible roundness as used in Windows' default Ribbon.

This version is the one @harborsiem suggested, and I would finally use cause of the lowest impact possible :)